### PR TITLE
fix: Fix source issue #1

### DIFF
--- a/tasks/exec_path.yml
+++ b/tasks/exec_path.yml
@@ -10,6 +10,3 @@
    path: /etc/environment
    line: PATH="$PATH:/opt/mariadb/bin"
    state: present
-
-- name: Source /etc/environment
-  command: source /etc/environment


### PR DESCRIPTION
Apply a fix to resolve source /etc/environment issues, the user will now manually have to relogin to be able to access the `mysql` commands. 

Reference issue: #1 